### PR TITLE
Update i18n function

### DIFF
--- a/plugin/src/openshift/i18n.ts
+++ b/plugin/src/openshift/i18n.ts
@@ -1,6 +1,18 @@
-import i18next from 'i18next';
+import i18next, { i18n as I18nInstance } from 'i18next';
+import { getI18n } from 'react-i18next';
 
-// OpenShift comes with its own i18n object. Creating a dummy one to avoid import errors in Kiali code
-i18next.init({});
+const fallbackI18n = i18next.createInstance();
+void fallbackI18n.init({ fallbackLng: 'en' });
 
-export const i18n = i18next;
+const resolveI18n = (): I18nInstance => getI18n() ?? fallbackI18n;
+
+// Kiali code imports `i18n` directly, but OSSMC relies on the react-i18next instance
+// provided by the OpenShift console. Delegating here keeps helper-based translations
+// in sync with the active UI language instead of falling back to English.
+export const i18n = new Proxy(fallbackI18n as I18nInstance, {
+  get: (_target, prop) => {
+    const activeI18n = resolveI18n() as unknown as object;
+    const value = Reflect.get(activeI18n, prop);
+    return typeof value === 'function' ? value.bind(resolveI18n()) : value;
+  }
+}) as I18nInstance;

--- a/plugin/src/openshift/i18n.ts
+++ b/plugin/src/openshift/i18n.ts
@@ -13,6 +13,6 @@ export const i18n = new Proxy(fallbackI18n as I18nInstance, {
   get: (_target, prop) => {
     const activeI18n = resolveI18n() as unknown as object;
     const value = Reflect.get(activeI18n, prop);
-    return typeof value === 'function' ? value.bind(resolveI18n()) : value;
+    return typeof value === 'function' ? value.bind(activeI18n) : value;
   }
 }) as I18nInstance;


### PR DESCRIPTION
### Describe the change

The Spanish translation for strings like Last {{duration}} already existed in the Kiali locale files, but in OSSMC the i18n alias was pointing to a dummy local i18next instance in plugin/src/openshift/i18n.ts. Because of that, some Kiali code paths, especially the ones using the helper t(...) instead of the active React translation context, were not reading the real loaded namespace and were falling back to the default English text.

### Steps to test the PR

Recommendations for how to test this PR. Reminder that each PR should also include a "Test" label.

### Automation testing

If applicable, explain the case scencarios covered by **e2e** tests created for this PR.

### Issue reference

If this PR is related to a github issue, please link it here ([more info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
